### PR TITLE
Update date of death feature and select a status page

### DIFF
--- a/app/views/layout-key-details-report-ready-extended.html
+++ b/app/views/layout-key-details-report-ready-extended.html
@@ -1,0 +1,265 @@
+{#- We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework. -#}
+{%- set assetPath = '/govuk/assets' -%}
+
+{% extends "govuk/template.njk" %}
+
+{% from "govuk/components/accordion/macro.njk"        import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk"        import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk"      import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk"           import govukButton %}
+{% from "govuk/components/character-count/macro.njk"  import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk"       import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk"       import govukDateInput %}
+{% from "govuk/components/details/macro.njk"          import govukDetails %}
+{% from "govuk/components/error-message/macro.njk"    import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk"    import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk"         import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk"      import govukFileUpload %}
+{% from "govuk/components/input/macro.njk"            import govukInput %}
+{% from "govuk/components/inset-text/macro.njk"       import govukInsetText %}
+{% from "govuk/components/panel/macro.njk"            import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk"     import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk"           import govukRadios %}
+{% from "govuk/components/select/macro.njk"           import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk"        import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk"     import govukSummaryList %}
+{% from "govuk/components/table/macro.njk"            import govukTable %}
+{% from "govuk/components/tabs/macro.njk"             import govukTabs %}
+{% from "govuk/components/tag/macro.njk"              import govukTag %}
+{% from "govuk/components/textarea/macro.njk"         import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk"     import govukWarningText %}
+
+{% block head %}
+  {% include "includes/head.html" %}
+{% endblock %}
+
+{% block pageTitle %}
+  GOV.UK Prototype Kit
+{% endblock %}
+
+{% block header %}
+
+<header class="govuk-header " role="banner" data-module="govuk-header">
+  <div class="govuk-header__container govuk-width-container  govuk-width-container--extended">
+    <div class="govuk-header__logo">
+      <a href="/index" class="govuk-header__link govuk-header__link--homepage">
+          <span class="govuk-header__logotype-text">
+            Health Assessment Service
+          </span>
+      </a>
+    </div>
+    <!-- <div class="govuk-header__content">
+      <a href="#" class="govuk-header__link govuk-header__link--service-name">
+        Service name
+      </a>
+    </div> -->
+  </div>
+</header>
+
+{% block assess_content %}
+
+<!-- Styling of head and keydetails bar -->
+<style type="text/css">
+
+  .govuk-header {
+    border-bottom: 0px solid #000000;
+  }
+
+  .govuk-header__container {
+    border-bottom: 0px;
+  }
+
+  .govuk-header__logo {margin-bottom: 0px;
+    padding-bottom: 10px;}
+
+.key-details-bar {
+  background-color: #1D70B8;
+}
+
+.key-details-bar .key-details-bar__key-details {
+  margin: 0 auto;
+  max-width: 1130px;
+  padding: 20px 30px 20px 60px;
+  position: relative;
+  font-family: "Arial";
+}
+
+@media (max-width: 670px) {
+  .key-details-bar .key-details-bar__key-details {
+    padding: 20px 15px;
+  }
+}
+
+.key-details-bar .key-details-bar__key-details * {
+  color: #fff;
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__top-block::after,
+.key-details-bar .key-details-bar__key-details .key-details-bar__bottom-block::after {
+  clear: both;
+  content: ' ';
+  display: block;
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__bottom-block {
+  border-top: 1px solid rgba(255, 255, 255, 0.3);
+  content: ' ';
+  padding-top: 10px;
+  margin-top: 6px;
+}
+
+@media (max-width: 670px) {
+  .key-details-bar .key-details-bar__key-details .key-details-bar__bottom-block {
+    border: 0;
+  }
+}
+
+.key-details-bar .key-details-bar__key-details dd,
+.key-details-bar .key-details-bar__key-details dt {
+  float: left;
+  font-size: 19px;
+  margin-right: 5px;
+}
+
+@media (max-width: 670px) {
+  .key-details-bar .key-details-bar__key-details dd,
+  .key-details-bar .key-details-bar__key-details dt {
+    float: none;
+    font-size: 16px;
+    margin: 0;
+  }
+}
+
+.key-details-bar .key-details-bar__key-details dd {
+  margin-right: 20px;
+}
+
+@media (max-width: 670px) {
+  .key-details-bar .key-details-bar__key-details dd {
+    margin-bottom: 20px;
+  }
+  .key-details-bar .key-details-bar__key-details dd:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__name {
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1.11111;
+  margin-right: 10px;
+}
+
+@media (max-width: 670px) {
+  .key-details-bar .key-details-bar__key-details .key-details-bar__name {
+    font-size: 24px;
+    line-height: 1.04167;
+    float: left;
+    margin: 0 5px 0 0;
+  }
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__nino {
+  font-size: 24px;
+  line-height: 1;
+  margin-top: 12px;
+}
+
+@media (max-width: 670px) {
+  .key-details-bar .key-details-bar__key-details .key-details-bar__nino {
+    font-size: 18px;
+    float: left;
+    margin: 5px 0 0 0;
+  }
+}
+
+.key-details-bar .key-details-bar__key-details .key-details-bar__status {
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.25;
+  padding: 5px 8px 0;
+  color: #1D70B8;
+  background-color: #fff;
+  letter-spacing: 1px;
+  text-decoration: none;
+  text-transform: uppercase;
+  float: right;
+  margin: 5px 0 0;
+}
+
+@media (max-width: 670px) {
+  .key-details-bar .key-details-bar__key-details .key-details-bar__status {
+    font-size: 14px;
+    float: left;
+    clear: both;
+    margin-top: 5px;
+  }
+}
+
+#global-header .header-wrapper{
+max-width:1160px !important;}
+</style>
+
+<section class="key-details-bar" role="contentinfo" aria-label="Key details">
+  <dl class="key-details-bar__key-details">
+    <div class="key-details-bar__top-block">
+      <dt class="govuk-visually-hidden">Name:</dt>
+      <dt class="key-details-bar__name">Sam Doe</dt>
+
+      <dt class="govuk-visually-hidden">National Insurance number:</dt>
+      <dt class="key-details-bar__nino">RN 00 01 23 A</dt>
+
+      <dt class="govuk-visually-hidden">Claim status:</dt>
+      <dd class="key-details-bar__status">Report ready</dd>
+    </div>
+
+    <div class="key-details-bar__bottom-block">
+      <dt>Date of birth:</dt>
+      <dd>31 December 1969</dd>
+    </div>
+  </dl>
+</section>
+
+
+
+
+{% endblock %}
+
+
+{% endblock %}
+
+
+
+{% set containerClasses = 'govuk-width-container--extended' %}
+
+{% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing govuk-width-container--extended") %}
+
+
+
+
+{% if useAutoStoreData %}
+  {% block footer %}
+    {{ govukFooter({
+      meta: {
+        items: [
+          {
+            href: "https://govuk-prototype-kit.herokuapp.com/",
+            text: ""
+          },
+          {
+            href: "/prototype-admin/clear-data",
+            text: ""
+          }
+        ]
+      }
+    }) }}
+  {% endblock %}
+{% endif %}
+
+{% block bodyEnd %}
+  {% block scripts %}
+    {% include "includes/scripts.html" %}
+    {% block pageScripts %}{% endblock %}
+  {% endblock %}
+  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
+{% endblock %}

--- a/app/views/pip-has-integration/v1/pip-case-details-updated.html
+++ b/app/views/pip-has-integration/v1/pip-case-details-updated.html
@@ -193,7 +193,7 @@
           Date of death
         </dt>
         <dd class="govuk-summary-list__value">
-          {{ data["dod-day"] }}
+          {{ data["dod-day"]}} &nbsp; {{ data["dod-month"]}} &nbsp; {{ data["dod-year"]}}
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link" href="change-singular/personal-dod">

--- a/app/views/pip-has-integration/v1/pip-case-details.html
+++ b/app/views/pip-has-integration/v1/pip-case-details.html
@@ -769,7 +769,9 @@ PIP
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="govuk-list">
             <li>
-              <a href=" ">Update status</a>
+              
+              <a href="update-status-pip" class="govuk-link govuk-link--no-visited-state">Update status</a>
+              
             </li>
             <li>
               <a href=" ">View timeline</a>

--- a/app/views/pip-has-integration/v1/update-status-pip.html
+++ b/app/views/pip-has-integration/v1/update-status-pip.html
@@ -1,11 +1,11 @@
-{% extends "layout-extended.html" %}
+{% extends "layout-key-details-report-ready-extended.html" %}
 
 {% block pageTitle %}
   Referral list
 {% endblock %}
 
 {% block beforeContent %}
-<a href="index" class="govuk-back-link">Back</a>
+<a href="pip-case-details.html" class="govuk-back-link">Back</a>
 {% endblock %}
 
 {% block content %}
@@ -26,97 +26,121 @@
             </legend>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-1" name="status" type="radio" value="hcp-review-pip">
+              <input class="govuk-radios__input" id="status-1" name="status" type="radio" value="assigned-pip">
+              <label class="govuk-label govuk-radios__label" for="status-1">
+                Assigned
+              </label>
+            </div>
+            
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="status-2" name="status" type="radio" value="hcp-review-pip">
               <label class="govuk-label govuk-radios__label" for="status-1">
                 HCP review
               </label>
             </div>
+
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-2" name="status" type="radio" value="send-fme-pip">
+              <input class="govuk-radios__input" id="status-3" name="status" type="radio" value="send-fme-pip">
               <label class="govuk-label govuk-radios__label" for="status-2">
                 Request medical evidence
               </label>
             </div>
+
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-3" name="status" type="radio" value="awaiting-fme-pip">
+              <input class="govuk-radios__input" id="status-4" name="status" type="radio" value="awaiting-fme-pip">
               <label class="govuk-label govuk-radios__label" for="status-3">
                 Awaiting medical evidence
               </label>
             </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-4" name="status" type="radio" value="fme-received-pip">
-              <label class="govuk-label govuk-radios__label" for="status-4">
-                Medical evidence received
-              </label>
-            </div>
+
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="status-5" name="status" type="radio" value="fme-not-received-pip">
               <label class="govuk-label govuk-radios__label" for="status-5">
                 Medical evidence not received
               </label>
             </div>
+
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-6" name="status" type="radio" value="book-assessment-pip">
+              <input class="govuk-radios__input" id="status-6" name="status" type="radio" value="fme-received-pip">
+              <label class="govuk-label govuk-radios__label" for="status-4">
+                Medical evidence received
+              </label>
+            </div>
+
+
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="status-7" name="status" type="radio" value="book-assessment-pip">
               <label class="govuk-label govuk-radios__label" for="status-6">
                 Book assessment
               </label>
             </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-7" name="status" type="radio" value="book-pbr-pip">
-              <label class="govuk-label govuk-radios__label" for="status-7">
-                Book paper based review
-              </label>
-            </div>
+
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="status-8" name="status" type="radio" value="assessment-booked-pip">
               <label class="govuk-label govuk-radios__label" for="status-8">
                 Assessment booked
               </label>
             </div>
+
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-9" name="status" type="radio" value="pbr-booked-pip">
-              <label class="govuk-label govuk-radios__label" for="status-9">
-                Paper based review booked
+              <input class="govuk-radios__input" id="status-9" name="status" type="radio" value="book-pbr-pip">
+              <label class="govuk-label govuk-radios__label" for="status-7">
+                PIP paper based review
               </label>
             </div>
+
+
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="status-10" name="status" type="radio" value="fta-pip">
               <label class="govuk-label govuk-radios__label" for="status-10">
                 Failed to attend
               </label>
             </div>
+
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-11" name="status" type="radio" value="hcp-audit-pip">
-              <label class="govuk-label govuk-radios__label" for="status-11">
-                HCP audit
-              </label>
-            </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-12" name="status" type="radio" value="report-ready-pip">
+              <input class="govuk-radios__input" id="status-11" name="status" type="radio" value="report-ready-pip">
               <label class="govuk-label govuk-radios__label" for="status-12">
                 Report ready
               </label>
             </div>
+
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-13" name="status" type="radio" value="pipcs-descriptors-updated">
-              <label class="govuk-label govuk-radios__label" for="status-13">
-                PIPCS descriptor updated
+              <input class="govuk-radios__input" id="status-12" name="status" type="radio" value="hcp-audit-pip">
+              <label class="govuk-label govuk-radios__label" for="status-11">
+                HCP audit
               </label>
             </div>
+
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-14" name="status" type="radio" value="done-pip">
+              <input class="govuk-radios__input" id="status-13" name="status" type="radio" value="cancelled-report-pip">
+              <label class="govuk-label govuk-radios__label" for="status-13">
+                Cancelled report
+              </label>
+            </div>
+
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="status-14" name="status" type="radio" value="assessment-not-completed-pip">
+              <label class="govuk-label govuk-radios__label" for="status-13">
+                Assessment not completed
+              </label>
+            </div>
+
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="status-15" name="status" type="radio" value="done-pip">
               <label class="govuk-label govuk-radios__label" for="status-14">
                 Done
               </label>
             </div>
+
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-15" name="status" type="radio" value="withdrawn-pip">
+              <input class="govuk-radios__input" id="status-16" name="status" type="radio" value="withdrawn-pip">
               <label class="govuk-label govuk-radios__label" for="status-15">
                 Withdrawn
               </label>
             </div>
+
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-16" name="status" type="radio" value="created-in-error-pip">
+              <input class="govuk-radios__input" id="status-17" name="status" type="radio" value="created-in-error-pip">
               <label class="govuk-label govuk-radios__label" for="status-16">
                 Created in error
               </label>
@@ -126,7 +150,7 @@
         </div>
 
         <a href="confirmation" role="button" draggable="false" class="govuk-button"  data-module="govuk-button">
-          Save and continue
+          Continue
         </a>
 
     </div>


### PR DESCRIPTION
- Edited date of death feature so the data (date) from the date of death form page is pulled through to the referral details page (the page version with success banner)

- Update status link on referral details page can now be clicked and goes through to select a status page

- Select a status page radio options updated to reflect the ordering and radio options in live