### PR TITLE
Updated the 'Update status' righthand links

### DIFF
--- a/app/views/pip-has-integration/v1/pip-case-details-updated.html
+++ b/app/views/pip-has-integration/v1/pip-case-details-updated.html
@@ -1088,7 +1088,7 @@ PIP
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="govuk-list">
             <li>
-              <a href="#">Update status</a>
+              <a href="update-status-pip" class="govuk-link govuk-link--no-visited-state">Update status</a>
             </li>
             <li>
               <a href=" ">View timeline</a>

--- a/app/views/pip-has-integration/v1/pip-claimant-detail-updated.html
+++ b/app/views/pip-has-integration/v1/pip-claimant-detail-updated.html
@@ -478,7 +478,7 @@ Sam Doe
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="govuk-list">
             <li>
-              <a href=" ">Update status</a>
+              <a href="update-status-pip" class="govuk-link govuk-link--no-visited-state">Update status</a>
             </li>
             <li>
               <a href=" ">View timeline</a>

--- a/app/views/pip-has-integration/v1/pip-claimant-detail.html
+++ b/app/views/pip-has-integration/v1/pip-claimant-detail.html
@@ -445,7 +445,7 @@ Sam Doe
         <nav role="navigation" aria-labelledby="subsection-title">
           <ul class="govuk-list">
             <li>
-              <a href=" ">Update status</a>
+              <a href="update-status-pip" class="govuk-link govuk-link--no-visited-state">Update status</a>
             </li>
             <li>
               <a href=" ">View timeline</a>


### PR DESCRIPTION
Updated the 'Update status' righthand link on the claimant details page, claimant details updated page, pip case details updated, so they all go through to the 'Select a status' page