### PR TITLE
Added radio options redirects and new final statuses

### DIFF
--- a/app/views/pip-has-integration/v1/update-status-pip.html
+++ b/app/views/pip-has-integration/v1/update-status-pip.html
@@ -33,35 +33,35 @@
             </div>
             
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-2" name="status" type="radio" value="hcp-review-pip~~/pip-has-integration/v1/confirmation">
+              <input class="govuk-radios__input" id="status-2" name="status" type="radio" value="hcp-review-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-1">
                 HCP review
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-3" name="status" type="radio" value="send-fme-pip">
+              <input class="govuk-radios__input" id="status-3" name="status" type="radio" value="send-fme-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-2">
                 Request medical evidence
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-4" name="status" type="radio" value="awaiting-fme-pip">
+              <input class="govuk-radios__input" id="status-4" name="status" type="radio" value="awaiting-fme-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-3">
                 Awaiting medical evidence
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-5" name="status" type="radio" value="fme-not-received-pip">
+              <input class="govuk-radios__input" id="status-5" name="status" type="radio" value="fme-not-received-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-5">
                 Medical evidence not received
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-6" name="status" type="radio" value="fme-received-pip">
+              <input class="govuk-radios__input" id="status-6" name="status" type="radio" value="fme-received-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-4">
                 Medical evidence received
               </label>
@@ -69,21 +69,21 @@
 
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-7" name="status" type="radio" value="book-assessment-pip">
+              <input class="govuk-radios__input" id="status-7" name="status" type="radio" value="book-assessment-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-6">
                 Book assessment
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-8" name="status" type="radio" value="assessment-booked-pip">
+              <input class="govuk-radios__input" id="status-8" name="status" type="radio" value="assessment-booked-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-8">
                 Assessment booked
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-9" name="status" type="radio" value="book-pbr-pip">
+              <input class="govuk-radios__input" id="status-9" name="status" type="radio" value="book-pbr-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-7">
                 PIP paper based review
               </label>
@@ -91,35 +91,35 @@
 
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-10" name="status" type="radio" value="fta-pip">
+              <input class="govuk-radios__input" id="status-10" name="status" type="radio" value="fta-pip~/pip-has-integration/v1/interrupt-page">
               <label class="govuk-label govuk-radios__label" for="status-10">
                 Failed to attend
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-11" name="status" type="radio" value="report-ready-pip">
+              <input class="govuk-radios__input" id="status-11" name="status" type="radio" value="report-ready-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-12">
                 Report ready
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-12" name="status" type="radio" value="hcp-audit-pip">
+              <input class="govuk-radios__input" id="status-12" name="status" type="radio" value="hcp-audit-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-11">
                 HCP audit
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-13" name="status" type="radio" value="cancelled-report-pip">
+              <input class="govuk-radios__input" id="status-13" name="status" type="radio" value="cancelled-report-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-13">
                 Cancelled report
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-14" name="status" type="radio" value="assessment-not-completed-pip">
+              <input class="govuk-radios__input" id="status-14" name="status" type="radio" value="assessment-not-completed-pip~/pip-has-integration/v1/interrupt-page">
               <label class="govuk-label govuk-radios__label" for="status-13">
                 Assessment not completed
               </label>
@@ -133,18 +133,34 @@
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-16" name="status" type="radio" value="withdrawn-pip">
+              <input class="govuk-radios__input" id="status-16" name="status" type="radio" value="withdrawn-pip~/pip-has-integration/v1/interrupt-page">
               <label class="govuk-label govuk-radios__label" for="status-15">
                 Withdrawn
               </label>
             </div>
 
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="status-17" name="status" type="radio" value="created-in-error-pip">
+              <input class="govuk-radios__input" id="status-17" name="status" type="radio" value="created-in-error-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-16">
                 Created in error
               </label>
             </div>
+
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="status-18" name="status" type="radio" value="dead-pip~/pip-has-integration/v1/interrupt-page">
+              <label class="govuk-label govuk-radios__label" for="status-15">
+                Dead
+              </label>
+            </div>
+
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="status-19" name="status" type="radio" value="return-to-pip-service-pip~/pip-has-integration/v1/interrupt-page">
+              <label class="govuk-label govuk-radios__label" for="status-15">
+                Return to PIP Service
+              </label>
+            </div>
+
+
 </div>
 </div>
           </fieldset>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "health-workflow-24-prototype",
+  "name": "health-workflow-24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
For PIP HAS integration v1 prototype

On Select a status page:

-Added  new final statuses to the radio options
-Set up radio button redirects, so if user chooses a final status they will be directed to an interruption  page. If user chooses a standard status they will be taken to the normal confirmation page