### PR TITLE
Changed 'Add' links to 'Change'

### DIFF
--- a/app/views/pip-has-integration/v1/pip-case-details-updated.html
+++ b/app/views/pip-has-integration/v1/pip-case-details-updated.html
@@ -197,7 +197,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link" href="change-singular/personal-dod">
-            Add<span class="govuk-visually-hidden"> Date of death</span>
+            Change<span class="govuk-visually-hidden"> Date of death</span>
           </a>
         </dd>
       </div>

--- a/app/views/pip-has-integration/v1/pip-claimant-detail-updated.html
+++ b/app/views/pip-has-integration/v1/pip-claimant-detail-updated.html
@@ -313,7 +313,7 @@ Sam Doe
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="change-singular/interpreter">
-              Add<span class="govuk-visually-hidden"> HCP preference</span>
+              Change<span class="govuk-visually-hidden"> HCP preference</span>
             </a>
           </dd>
         </div>


### PR DESCRIPTION
On the updated pip case details and claimant details page, the 'Add' link is changed to a 'Change link, because details have already been added