### PR TITLE
Moved Date of death field onto claimant details page

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -7,7 +7,7 @@ filters.toMonth = function(x) {
     if (x > 0 && x <= 12) {
         return months[x - 1]; // returns the month as per x
     } else {
-        return 'Invalid month'; // Handle invalid month
+        return ''; // Handle invalid month
     }
 };
 filters.toMoney = function(x) {

--- a/app/views/pip-has-integration/v1/change-singular/personal-dod.html
+++ b/app/views/pip-has-integration/v1/change-singular/personal-dod.html
@@ -20,7 +20,7 @@ Date of death - Health Assessment Service
     
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" role="group" aria-describedby="claimant-names">
-        <form class="form" action="../pip-case-details-updated" method="post">
+        <form class="form" action="../pip-claimant-detail-updated" method="post">
       
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h2 class="govuk-fieldset__heading">

--- a/app/views/pip-has-integration/v1/pip-case-details-updated.html
+++ b/app/views/pip-has-integration/v1/pip-case-details-updated.html
@@ -188,7 +188,7 @@
       </div>
 
 
-      <div class="govuk-summary-list__row">
+      <!-- <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Date of death
         </dt>
@@ -200,7 +200,7 @@
             Change<span class="govuk-visually-hidden"> Date of death</span>
           </a>
         </dd>
-      </div>
+      </div>-->
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/app/views/pip-has-integration/v1/pip-case-details.html
+++ b/app/views/pip-has-integration/v1/pip-case-details.html
@@ -147,21 +147,6 @@
         </div>
 
 
-
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Date of death
-          </dt>
-          <dd class="govuk-summary-list__value">
-
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="change-singular/personal-dod">
-              Add<span class="govuk-visually-hidden"> Date of death</span>
-            </a>
-          </dd>
-        </div>
-
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Safety measures

--- a/app/views/pip-has-integration/v1/pip-claimant-detail-updated.html
+++ b/app/views/pip-has-integration/v1/pip-claimant-detail-updated.html
@@ -163,6 +163,21 @@ Sam Doe
           </a> -->
         </dd>
       </div>
+
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Date of death
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data["dod-day"]}} &nbsp; {{ data["dod-month"] | toMonth }} &nbsp; {{ data["dod-year"]}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="change-singular/personal-dod">
+            Change<span class="govuk-visually-hidden"> Date of death</span>
+          </a>
+        </dd>
+      </div>
        
       <!-- <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/app/views/pip-has-integration/v1/pip-claimant-detail.html
+++ b/app/views/pip-has-integration/v1/pip-claimant-detail.html
@@ -126,6 +126,22 @@ Sam Doe
           </a> -->
         </dd>
       </div>
+
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Date of death
+        </dt>
+        <dd class="govuk-summary-list__value">
+
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="change-singular/personal-dod">
+            Add<span class="govuk-visually-hidden"> Date of death</span>
+          </a>
+        </dd>
+      </div>
+      
       
       <!-- <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">


### PR DESCRIPTION
For PIP HAS integration v1 prototype - moved Date of death field from the Referral details page to the claimant details page, as instructed by product owner