### PR TITLE
v7.1 prototype -  Moved Date of death field onto claimant details page

### DIFF
--- a/app/views/richer-claimant-info/v7-1/change-singular/personal-dod.html
+++ b/app/views/richer-claimant-info/v7-1/change-singular/personal-dod.html
@@ -20,25 +20,26 @@ Date of death - Health Assessment Service
     
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" role="group" aria-describedby="claimant-names">
+        <form class="form" action="../pip-claimant-detail-updated" method="post">
+      
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h2 class="govuk-fieldset__heading">
        Date of death
             </h2>
           </legend>
-       
-
           
 
           <div id="dob-hint" class="govuk-hint">
             If the claimant has died, enter the date of death. For example, 27 3 2007
           </div>
+
           <div class="govuk-date-input" id="dob">
             <div class="govuk-date-input__item">
               <div class="govuk-form-group">
                 <label class="govuk-label govuk-date-input__label" for="dod-day">
                   Day
                 </label>
-                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dod-day" name="dob-day" type="text" inputmode="numeric" >
+                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dod-day" name="dod-day" type="text" inputmode="numeric" >
               </div>
             </div>
             <div class="govuk-date-input__item">
@@ -46,7 +47,7 @@ Date of death - Health Assessment Service
                 <label class="govuk-label govuk-date-input__label" for="dod-month">
                   Month
                 </label>
-                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dod-month" name="dob-month" type="text" inputmode="numeric" >
+                <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="dod-month" name="dod-month" type="text" inputmode="numeric" >
               </div>
             </div>
             <div class="govuk-date-input__item">
@@ -68,10 +69,13 @@ Date of death - Health Assessment Service
      
 
 
-      <a href="../pip-case-details-updated">  <button class="govuk-button" data-module="govuk-button">
+      <!-- <a href="../pip-claimant-detail-updated">  -->
+        <button class="govuk-button" data-module="govuk-button">
         Continue
         </button>
-      </a>
+        </form>
+      <!-- </a> -->
+
 
     </div>
   </div>

--- a/app/views/richer-claimant-info/v7-1/pip-case-details-updated.html
+++ b/app/views/richer-claimant-info/v7-1/pip-case-details-updated.html
@@ -187,19 +187,7 @@
       </div>
 
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Date of death
-        </dt>
-        <dd class="govuk-summary-list__value">
 
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="change-singular/personal-dod">
-            Add<span class="govuk-visually-hidden"> Date of death</span>
-          </a>
-        </dd>
-      </div>
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/app/views/richer-claimant-info/v7-1/pip-case-details.html
+++ b/app/views/richer-claimant-info/v7-1/pip-case-details.html
@@ -149,20 +149,6 @@
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Date of death
-          </dt>
-          <dd class="govuk-summary-list__value">
-
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="change-singular/personal-dod">
-              Add<span class="govuk-visually-hidden"> Date of death</span>
-            </a>
-          </dd>
-        </div>
-
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
             Safety measures
           </dt>
           <dd class="govuk-summary-list__value">

--- a/app/views/richer-claimant-info/v7-1/pip-claimant-detail-updated.html
+++ b/app/views/richer-claimant-info/v7-1/pip-claimant-detail-updated.html
@@ -52,7 +52,7 @@
         </li>
 
         <li class="app-subnav__section-item app-subnav__section-item--current">
-          <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="#">Claimant
+          <a class="app-subnav__link govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="pip-claimant-detail.html">Claimant
             details</a>
           <ul class="app-subnav__section app-subnav__section--nested">
             <li class="app-subnav__section-item">
@@ -188,6 +188,21 @@ Sam Doe
           </a>-->
         </dd>
       </div>
+
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Date of death
+        </dt>
+        <dd class="govuk-summary-list__value">
+          {{ data["dod-day"]}} &nbsp; {{ data["dod-month"] | toMonth }} &nbsp; {{ data["dod-year"]}}
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="change-singular/personal-dod">
+            Change<span class="govuk-visually-hidden"> Date of death</span>
+          </a>
+        </dd>
+      </div> 
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/app/views/richer-claimant-info/v7-1/pip-claimant-detail.html
+++ b/app/views/richer-claimant-info/v7-1/pip-claimant-detail.html
@@ -152,6 +152,21 @@ Sam Doe
         </dd>
       </div>
 
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Date of death
+        </dt>
+        <dd class="govuk-summary-list__value">
+
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="change-singular/personal-dod">
+            Add<span class="govuk-visually-hidden"> Date of death</span>
+          </a>
+        </dd>
+      </div>
+
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
          Residential address


### PR DESCRIPTION
For Richer claimant info v7.1 prototype - moved Date of death field from the Referral details page to the claimant details page, as instructed by product owner