### PR TITLE
Updates to phone number fields and benefit type

### DIFF
--- a/app/views/pip-has-integration/v1/pip-case-details-updated.html
+++ b/app/views/pip-has-integration/v1/pip-case-details-updated.html
@@ -278,7 +278,7 @@
       Benefit type
     </dt>
     <dd class="govuk-summary-list__value">
-      PIP
+      PIP S
     </dd>
     <dd class="govuk-summary-list__value">
 

--- a/app/views/pip-has-integration/v1/pip-case-details.html
+++ b/app/views/pip-has-integration/v1/pip-case-details.html
@@ -223,7 +223,7 @@
           Benefit type
         </dt>
         <dd class="govuk-summary-list__value">
-          PIP
+          PIP S
         </dd>
         <dd class="govuk-summary-list__value">
 

--- a/app/views/pip-has-integration/v1/pip-claimant-detail-updated.html
+++ b/app/views/pip-has-integration/v1/pip-claimant-detail-updated.html
@@ -242,14 +242,14 @@ Sam Doe
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Home phone number
+          Mobile phone number
         </dt>
         <dd class="govuk-summary-list__value">
-          0121 423478
+          07800300300
         </dd>
         <dd class="govuk-summary-list__actions">
-          <!-- <a class="govuk-link" href="change-singular/personal-home-no">
-           Change<span class="govuk-visually-hidden"> Home phone number</span>
+          <!-- <a class="govuk-link" href="change-singular/personal-mob-no">
+            Change<span class="govuk-visually-hidden">Mobile phone number</span>
           </a> -->
         </dd>
       </div>
@@ -257,14 +257,14 @@ Sam Doe
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Mobile phone number
+          Alternative phone number
         </dt>
         <dd class="govuk-summary-list__value">
-          07000 000000
+          0121423478
         </dd>
         <dd class="govuk-summary-list__actions">
-          <!-- <a class="govuk-link" href="change-singular/personal-mob-no">
-            Change<span class="govuk-visually-hidden">Mobile phone number</span>
+          <!-- <a class="govuk-link" href="change-singular/personal-home-no">
+           Change<span class="govuk-visually-hidden"> Home phone number</span>
           </a> -->
         </dd>
       </div>

--- a/app/views/pip-has-integration/v1/pip-claimant-detail.html
+++ b/app/views/pip-has-integration/v1/pip-claimant-detail.html
@@ -201,25 +201,13 @@ Sam Doe
         </dd>
       </div> -->
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Home phone number
-        </dt>
-        <dd class="govuk-summary-list__value">
-          0121 423478
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <!-- <a class="govuk-link" href="change-singular/personal-home-no">
-           Change<span class="govuk-visually-hidden"> Home phone number</span>
-          </a> -->
-        </dd>
-      </div>
+
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Mobile phone number
         </dt>
         <dd class="govuk-summary-list__value">
-          07000 000000
+          07800300300
         </dd>
         <dd class="govuk-summary-list__actions">
           <!-- <a class="govuk-link" href="change-singular/personal-mob-no">
@@ -227,6 +215,23 @@ Sam Doe
           </a> -->
         </dd>
       </div>
+
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Alternative phone number
+        </dt>
+        <dd class="govuk-summary-list__value">
+          0121423478
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <!-- <a class="govuk-link" href="change-singular/personal-home-no">
+           Change<span class="govuk-visually-hidden"> Home phone number</span>
+          </a> -->
+        </dd>
+      </div>
+
+
 
     <!--   <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">


### PR DESCRIPTION
For PIP HAS integration prototype:

- Mobile phone number field on claimant details page is now the primary number positioned above the secondary number
- Home number field now changed to alternative phone number
- Benefit type filed on referral overview page changed from PIP to PIP S