### PR TITLE
Update view-caseload-or-status.html

### DIFF
--- a/app/views/pip-has-integration/v1/view-caseload-or-status.html
+++ b/app/views/pip-has-integration/v1/view-caseload-or-status.html
@@ -13,7 +13,12 @@ View a caseload or status
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <form action="list-1" method="post" class="form">
+
+
+
+
+      <!-- <form action="list-1" method="post" class="form"> -->
+    <form class="govuk-form-group" method="post">  
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" aria-describedby="view-hint">
@@ -29,7 +34,8 @@ View a caseload or status
 
             <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="view" name="view" type="radio" value="caseload" data-aria-controls="conditional-view">
+                <!-- <input class="govuk-radios__input" id="view" name="view" type="radio" value="caseload" data-aria-controls="conditional-view"> -->
+                <input class="govuk-radios__input" id="view" name="view" type="radio" value="caseload~/pip-has-integration/v1/list-1">
                 <label class="govuk-label govuk-radios__label" for="view">
                   Caseload
                 </label>
@@ -63,7 +69,8 @@ View a caseload or status
 
 
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="view-2" name="view" type="radio" value="status" data-aria-controls="conditional-view-2">
+                <!-- <input class="govuk-radios__input" id="view-2" name="view" type="radio" value="status" data-aria-controls="conditional-view-2"> -->
+                <input class="govuk-radios__input" id="view-2" name="view" type="radio" value="status~/pip-has-integration/v1/list-4">
                 <label class="govuk-label govuk-radios__label" for="view-2">
                   Status
                 </label>
@@ -183,7 +190,12 @@ View a caseload or status
           </fieldset>
         </div>
 
-      <button class="govuk-button" data-module="govuk-button">Continue</button>
+      <!-- <button class="govuk-button" data-module="govuk-button">Continue</button> -->
+      <br>
+      
+      <button type="submit" class="govuk-button" data-module="govuk-button">
+        Continue
+      </button>
     </form>
 
     </div>


### PR DESCRIPTION
Temporarily linked high level radios (caseload and status radios) to the relevant pages without selecting conditional reveal radio options. The conditional reveal is not working even after support from dev and kit support channel.