### PR TITLE
Update application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,7 +4,8 @@
 //
 
 window.GOVUKPrototypeKit.documentReady(() => {
-  // Add JavaScript here
+  window.GOVUKFrontend.initAll()
+  })
 
   const env = nunjucks.configure('views', {
     autoescape: true,
@@ -14,4 +15,4 @@ window.GOVUKPrototypeKit.documentReady(() => {
   env.addFilter('is_undefined', function(obj) {
     return typeof obj === 'undefined';
   });
-})
+


### PR DESCRIPTION
As advised by support colleague in prototype kit channel to fix the radio button conditional reveal problem:

So part of the migration that can fail is the JS file, if you go to app/assets/javascripts/application.js and check the top, it used to look like this… // Warn about using the kit in production
if (window.console && window.console.info) {
 window.console.info('GOV.UK Prototype Kit - do not use for production')
}

$(document).ready(function () {
 window.GOVUKFrontend.initAll()
})
…and it looks like that document ready is still trying to run, so you’d want to replace it with… window.GOVUKPrototypeKit.documentReady(() => {
 window.GOVUKFrontend.initAll()
 })