### PR TITLE
Making sure statuses match what's been released

### DIFF
--- a/app/views/pip-has-integration/v1/index.html
+++ b/app/views/pip-has-integration/v1/index.html
@@ -63,9 +63,9 @@ Health Assessment Service
       <div class="dwp-card dwp-card--clickable">
         <div class="dwp-card__content">
           <h2 class="dwp-card__heading dwp-heading-m">
-            <a class="dwp-card__link" href="#">Manage booked assessments</a>
+            <a class="dwp-card__link" href="#">Manage appointments</a>
           </h2>
-          <p class="dwp-card__description">View or cancel a booked assessment or assign a HCP</p>
+          <p class="dwp-card__description">Manage booked appointments</p>
         </div>
       </div>
 
@@ -73,9 +73,9 @@ Health Assessment Service
       <div class="dwp-card dwp-card--clickable">
         <div class="dwp-card__content">
           <h2 class="dwp-card__heading dwp-heading-m">
-            <a class="dwp-card__link" href="#">Manage HCP profiles</a>
+            <a class="dwp-card__link" href="#">Manage availability</a>
           </h2>
-          <p class="dwp-card__description">Add, edit or remove a HCP and their skills</p>
+          <p class="dwp-card__description">Manage healthcare professionals (HCPs) and their appointment availability</p>
         </div>
       </div>
 

--- a/app/views/pip-has-integration/v1/interrupt-page.html
+++ b/app/views/pip-has-integration/v1/interrupt-page.html
@@ -23,7 +23,7 @@ Confirm status update - Health Assessment Service
       <span class="govuk-caption-xl">Sam Doe</span>      
 
      <h1 class="govuk-heading-l">
-      Are you sure you want to update the status to 'done'?
+      Are you sure you want to update the status to 'Done'?
     </h3>
    
     <!-- <p class="govuk-body">Residential address updated.  </p> -->

--- a/app/views/pip-has-integration/v1/update-status-pip.html
+++ b/app/views/pip-has-integration/v1/update-status-pip.html
@@ -71,14 +71,21 @@
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="status-7" name="status" type="radio" value="book-assessment-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-6">
-                Book assessment
+                Book appointment
+              </label>
+            </div>
+
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="status-7" name="status" type="radio" value="book-assessment-pip~/pip-has-integration/v1/confirmation">
+              <label class="govuk-label govuk-radios__label" for="status-6">
+                Rebook appointment
               </label>
             </div>
 
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="status-8" name="status" type="radio" value="assessment-booked-pip~/pip-has-integration/v1/confirmation">
               <label class="govuk-label govuk-radios__label" for="status-8">
-                Assessment booked
+                Appointment booked
               </label>
             </div>
 

--- a/app/views/pip-has-integration/v1/view-caseload-or-status.html
+++ b/app/views/pip-has-integration/v1/view-caseload-or-status.html
@@ -136,11 +136,19 @@ View a caseload or status
                       </label>
                     </div>
                     <div class="govuk-radios__item">
-                      <input class="govuk-radios__input" id="status-10" name="status" type="radio" value="book-assessment">
+                      <input class="govuk-radios__input" id="status-10" name="status" type="radio" value="book-appointment">
                       <label class="govuk-label govuk-radios__label" for="status-10">
-                        Book assessment (12)
+                        Book appointment (12)
                       </label>
                     </div>
+
+                    <div class="govuk-radios__item">
+                      <input class="govuk-radios__input" id="status-10" name="status" type="radio" value="rebook-appointment">
+                      <label class="govuk-label govuk-radios__label" for="status-10">
+                        Rebook appointment (1)
+                      </label>
+                    </div>
+
                     <div class="govuk-radios__item">
                       <input class="govuk-radios__input" id="status-11" name="status" type="radio" value="book-pbr">
                       <label class="govuk-label govuk-radios__label" for="status-11">


### PR DESCRIPTION
- Adding 'Rebook appointment' status
- Changing terminology of some of the statuses to 'appointment' instead of 'assessment'
- Updating homepage to reflect latest release